### PR TITLE
Rename resumes on upload

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -71,7 +71,7 @@ def terms_and_conditions(request):
 def protectedMedia(request, file_):
     path, file_name = os.path.split(file_)
     downloadable_path = None
-    if path == "resumes":
+    if path.startswith("resumes"):
         try:
             app = HackerApplication.objects.get(resume=file_)
         except HackerApplication.DoesNotExist:

--- a/applications/models.py
+++ b/applications/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import json
+import os
 import uuid as uuid
 from datetime import datetime
 
@@ -111,6 +112,13 @@ YEARS = [(int(size), size) for size in ('2020 2021 2022 2023 2024 2025 2026'.spl
 DEFAULT_YEAR = datetime.now().year
 
 ENGLISH_LEVEL = [(i, str(i)) for i in range(1, 5 + 1)]
+
+
+def resume_path(dir_suffix):
+    def _resume_path(instance, filename):
+        (_, ext) = os.path.splitext(filename)
+        return 'resumes_{}/{}_{}{}'.format(dir_suffix, instance.user.name, instance.uuid, ext)
+    return _resume_path
 
 
 class BaseApplication(models.Model):
@@ -333,9 +341,6 @@ class _HackerMentorApplication(models.Model):
     linkedin = models.URLField(blank=True, null=True)
     site = models.URLField(blank=True, null=True)
 
-    # Giv me a resume here!
-    resume = models.FileField(upload_to='resumes', null=True, blank=True, validators=[validate_file_extension])
-
 
 class _VolunteerMentorApplication(models.Model):
     class Meta:
@@ -381,6 +386,13 @@ class HackerApplication(
     hardware = models.CharField(max_length=300, null=True, blank=True)
 
     cvs_edition = models.BooleanField(default=False)
+
+    resume = models.FileField(
+        upload_to=resume_path("hackers"),
+        null=True,
+        blank=True,
+        validators=[validate_file_extension],
+    )
 
     @classmethod
     def annotate_vote(cls, qs):
@@ -459,6 +471,12 @@ class MentorApplication(
     university = models.CharField(max_length=300, null=True, blank=True)
     degree = models.CharField(max_length=300, null=True, blank=True)
     participated = models.TextField(max_length=500, blank=True, null=True)
+    resume = models.FileField(
+        upload_to=resume_path("mentors"),
+        null=True,
+        blank=True,
+        validators=[validate_file_extension],
+    )
 
 
 class VolunteerApplication(


### PR DESCRIPTION
Renames resumes on upload using the following format: `<USER_NAME>_<USER_UUID>.pdf` as per https://github.com/hackupc/myhackupc/issues/135. It also saves mentor's resumes from hacker's in different directories (`resumes_mentors/` and `resumes_hackers/`, respectively)

Tested and working ✅ 
<img width="711" alt="image" src="https://user-images.githubusercontent.com/36073068/137628250-b8a110f7-3518-4190-8bac-7d4949c59bd7.png">
